### PR TITLE
#BE-800 Cache provider condition

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -75,7 +75,11 @@ unless ac_token_id.empty?
     signed = JSON.parse(response)
     ENV['AC_CACHE_GET_URL'] = signed['getUrl']
     puts ENV['AC_CACHE_GET_URL']
-    run_command_with_log("curl -X GET -H \"Content-Type: application/zip\" -o #{zipped} $AC_CACHE_GET_URL")
+    if get_env_variable('AC_CACHE_PROVIDER').eql?('FILESYSTEM')
+      run_command_with_log("curl -X GET -o #{zipped} '#{ENV['AC_CACHE_GET_URL']}'")
+    else
+      run_command_with_log("curl -X GET -H \"Content-Type: application/zip\" -o #{zipped} $AC_CACHE_GET_URL")
+    end
   end
 end
 


### PR DESCRIPTION
For self-hosted appcircle deployment, there is a different `curl` request. So we need to make `curl` call conditionally. (_gcloud, filesystem_)